### PR TITLE
Tab completion support in bash

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -54,6 +54,13 @@ Editor integrations
 
 - `vim-ped <https://github.com/sloria/vim-ped>`_
 
+Tab completion
+**************
+
+To install tab completion for ped commands in bash, run::
+
+    sudo python -m ped.bashcomplete
+
 Kudos
 *****
 

--- a/README.rst
+++ b/README.rst
@@ -59,7 +59,7 @@ Tab completion
 
 To install tab completion for ped commands in bash, run::
 
-    sudo python -m ped.bashcomplete
+    sudo python -m ped.bashcomplete /etc/bash_completion.d/
 
 Kudos
 *****

--- a/ped/__init__.py
+++ b/ped/__init__.py
@@ -13,23 +13,26 @@ import shlex
 import subprocess
 import sys
 
-from .guess_module import guess_module
+from .guess_module import guess_module, get_names_by_prefix
 
 __version__ = '1.4.0'
 
 def main():
     args = parse_args()
-    try:
-        ped(
-            module=args.module,
-            editor=args.editor,
-            info=args.info,
-        )
-    except ImportError:
-        print('ERROR: Could not find module in '
-              'current environment: "{0}"'.format(args.module),
-              file=sys.stderr)
-        sys.exit(1)
+    if args.complete:
+        complete(args.module)
+    else:
+        try:
+            ped(
+                module=args.module,
+                editor=args.editor,
+                info=args.info,
+            )
+        except ImportError:
+            print('ERROR: Could not find module in '
+                  'current environment: "{0}"'.format(args.module),
+                  file=sys.stderr)
+            sys.exit(1)
 
 def parse_args():
     parser = argparse.ArgumentParser(
@@ -41,6 +44,7 @@ def parse_args():
     parser.add_argument('-v', '--version', action='version', version=__version__)
     parser.add_argument('-i', '--info', action='store_true',
         help='output name, file path, and line number (if applicable) of module')
+    parser.add_argument('--complete', action='store_true', help=argparse.SUPPRESS)
     return parser.parse_args()
 
 def ped(module, editor=None, info=False):
@@ -54,6 +58,14 @@ def ped(module, editor=None, info=False):
         print('Editing {0}...'.format(module_name))
         edit_file(fpath, lineno=lineno, editor=editor)
         print('...Done.')
+
+def complete(ipath):
+    """Print possible module completions to stdout.
+    
+    :param str ipath: Partial import path to a module, function, or class.
+    """
+    for name in get_names_by_prefix(ipath):
+        print(name)
 
 def get_info(ipath):
     """Return module name, file path, and line number.

--- a/ped/bashcomplete.py
+++ b/ped/bashcomplete.py
@@ -1,0 +1,14 @@
+from __future__ import print_function
+
+import os
+import shutil
+
+def install():
+    # Is this right for all systems?
+    destination = '/etc/bash_completion.d/'
+    source = os.path.join(os.path.dirname(__file__), 'ped_bash_completion.sh')
+    print('Copying', source, 'to', destination)
+    shutil.copy(source, destination)
+
+if __name__ == '__main__':
+    install()

--- a/ped/bashcomplete.py
+++ b/ped/bashcomplete.py
@@ -1,9 +1,10 @@
 from __future__ import print_function
 
+import argparse
 import os
 import shutil
 
-def install():
+def install(destination):
     # Is this right for all systems?
     destination = '/etc/bash_completion.d/'
     source = os.path.join(os.path.dirname(__file__), 'ped_bash_completion.sh')
@@ -11,4 +12,8 @@ def install():
     shutil.copy(source, destination)
 
 if __name__ == '__main__':
-    install()
+    ap = argparse.ArgumentParser()
+    ap.add_argument('destination',
+            help='Directory to which to install completion script')
+    args = ap.parse_args()
+    install(args.destination)

--- a/ped/guess_module.py
+++ b/ped/guess_module.py
@@ -50,6 +50,10 @@ def get_possible_modules(name):
     completion_list = try_import('.'.join(mod[:-1]), True)
     return ['.'.join(mod[:-1] + [el]) for el in completion_list]
 
+def get_names_by_prefix(prefix):
+    for name in get_possible_modules(prefix):
+        if name.startswith(prefix):
+            yield name
 
 def get_root_modules():
     """Return a list containing the names of all the modules available in the

--- a/ped/ped_bash_completion.sh
+++ b/ped/ped_bash_completion.sh
@@ -1,0 +1,34 @@
+#  Completion for ped:
+#
+#  ped -e [editor]
+#  ped [module name]
+#
+_complete_ped() 
+{
+    local cur prev opts
+    COMPREPLY=()
+    cur="${COMP_WORDS[COMP_CWORD]}"
+    prev="${COMP_WORDS[COMP_CWORD-1]}"
+    opts="--editor --info --version"
+    
+    # --foo options
+    if [[ "${cur::1}" == "-" ]]
+    then
+        COMPREPLY=( $(compgen -W "${opts}" -- ${cur}) )
+        return 0
+    fi
+ 
+    case "${prev}" in
+    -e|--editor)
+        # Complete commands for editor flag
+        COMPREPLY=( $(compgen -c ${cur}) )
+            return 0
+            ;;
+    *)
+        ;;
+    esac
+
+    # Complete a module name
+    COMPREPLY=( $(ped --complete ${cur}) )
+}
+complete -F _complete_ped ped

--- a/setup.py
+++ b/setup.py
@@ -56,5 +56,10 @@ setup(
         'console_scripts': [
             "ped = ped:main"
         ]
-    }
+    },
+    package_data={
+        'ped': [
+            "ped_bash_completion.sh",
+        ]
+    },
 )


### PR DESCRIPTION
This is a rough go at implementing tab completion of module names in bash.

To test it out, `source ped_bash_completion.sh` and then try completing ped commands in the same shell. To make it permanent, copy that file into `/etc/bash_completions.d/`

If you're happy with this approach, I'll ensure that the file is packaged and installed with ped, and make an easy way to install it to the correct location.