### PR TITLE
Update pipx run command

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -44,11 +44,11 @@ From PyPI:
     $ pip install ped
 
 
-Or, run it with `pipx <https://github.com/cs01/pipx>`_:
+Or, run it with `pipx <https://github.com/pipxproject/pipx>`_:
 
 ::
 
-    $ pipx ped --help
+    $ pipx run ped --help
 
 
 Changing the default editor


### PR DESCRIPTION
The pipx API has changed, and now requires the command `run`